### PR TITLE
Retina Check

### DIFF
--- a/aq_resizer.php
+++ b/aq_resizer.php
@@ -23,6 +23,12 @@
 
 function aq_resize( $url, $width, $height = null, $crop = null, $single = true ) {
 	
+	//retina check - if the wp-retina-2x plugin is installed, follow suit and double the size of images
+	if (  in_array( 'wp-retina-2x/wp-retina-2x.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) { 
+		$width = $width * 2;
+		$height = $height * 2;
+	}
+	
 	//validate inputs
 	if(!$url OR !$width ) return false;
 	


### PR DESCRIPTION
If the user has the wp-retina-2x plugin installed, follow suit and double the width and height of the images.
