### PR TITLE
More dynamic and strictness

### DIFF
--- a/aq_resizer.php
+++ b/aq_resizer.php
@@ -62,7 +62,7 @@ function aq_resize( $url, $width = null, $height = null, $crop = null, $single =
 		$dst_rel_path = str_replace( '.'.$ext, '', $rel_path);
 		$destfilename = "{$upload_dir}{$dst_rel_path}-{$suffix}.{$ext}";
 		
-		if(!$dims || $dst_w < $width || $dst_h < $height) {
+		if(!$dims || ($crop == true && ($dst_w < $width || $dst_h < $height))) {
 			//can't resize, so return false saying that the action to do could not be processed as planned.
             return false;
 		}


### PR DESCRIPTION
1. Commit adds the ability to resize on height, too, and leave width free. It removes absolutely no functionality.
2. Commit is enhances good behaviour. I think, it's somehow arbitrary to return just a partly resized image if one site extends the original length (for example if You want to resize an image with 100x100 to 110x90 it used to become a 100x90 image, which is hard to handle). Imho it is best to stay over everything and to have the ability to handle every detail. This way, You can now just check like 

<pre><code>$resized_image_url = aqua_resize($image_url, $width, $height);
if(!$resized_image_url) {
    // handle that
}
</code></pre>


If You want to resize an image to it's original size the script will return the image url from the arguments (which is the same for the case that only either width or height has been passed but the image size is still the same - done at line 55).

There is still some room for improvement in my opinion, especially at the point that now it will return false if some technical error occures _and_ the original image is not as large as the resizing arguments. There should be a way to distinguish these two possibilities, but I think we could discuss that if You find the changes made by me useful.

PS.: changes in every line come from the fact that I converted all indentation to spaces.
