### PR TITLE
Improved error handling

### DIFF
--- a/aq_resizer.php
+++ b/aq_resizer.php
@@ -23,12 +23,20 @@
  */
 
 if(!class_exists('Aq_Resize')) {
+    class Aq_Exception extends Exception {}
+
     class Aq_Resize
     {
         /**
          * The singleton instance
          */
         static private $instance = null;
+
+        /**
+         * Should an Aq_Exception be thrown on error?
+         * If false (default), then the error will just be logged.
+         */
+        public $throwOnError = false;
 
         /**
          * No initialization allowed
@@ -55,106 +63,129 @@ if(!class_exists('Aq_Resize')) {
          * Run, forest.
          */
         public function process( $url, $width = null, $height = null, $crop = null, $single = true, $upscale = false ) {
-            // Validate inputs.
-            if ( ! $url || ( ! $width && ! $height ) ) return false;
+            try {
+                // Validate inputs.
+                if (!$url)
+                    throw new Aq_Exception('$url parameter is required');
+                if (!$width)
+                    throw new Aq_Exception('$width parameter is required');
+                if (!$height)
+                    throw new Aq_Exception('$height parameter is required');
 
-            // Caipt'n, ready to hook.
-            if ( true === $upscale ) add_filter( 'image_resize_dimensions', array($this, 'aq_upscale'), 10, 6 );
+                // Caipt'n, ready to hook.
+                if ( true === $upscale ) add_filter( 'image_resize_dimensions', array($this, 'aq_upscale'), 10, 6 );
 
-            // Define upload path & dir.
-            $upload_info = wp_upload_dir();
-            $upload_dir = $upload_info['basedir'];
-            $upload_url = $upload_info['baseurl'];
-            
-            $http_prefix = "http://";
-            $https_prefix = "https://";
-            
-            /* if the $url scheme differs from $upload_url scheme, make them match 
-               if the schemes differe, images don't show up. */
-            if(!strncmp($url,$https_prefix,strlen($https_prefix))){ //if url begins with https:// make $upload_url begin with https:// as well
-                $upload_url = str_replace($http_prefix,$https_prefix,$upload_url);
+                // Define upload path & dir.
+                $upload_info = wp_upload_dir();
+                $upload_dir = $upload_info['basedir'];
+                $upload_url = $upload_info['baseurl'];
+                
+                $http_prefix = "http://";
+                $https_prefix = "https://";
+                
+                /* if the $url scheme differs from $upload_url scheme, make them match 
+                   if the schemes differe, images don't show up. */
+                if(!strncmp($url,$https_prefix,strlen($https_prefix))){ //if url begins with https:// make $upload_url begin with https:// as well
+                    $upload_url = str_replace($http_prefix,$https_prefix,$upload_url);
+                }
+                elseif(!strncmp($url,$http_prefix,strlen($http_prefix))){ //if url begins with http:// make $upload_url begin with http:// as well
+                    $upload_url = str_replace($https_prefix,$http_prefix,$upload_url);      
+                }
+                
+
+                // Check if $img_url is local.
+                if ( false === strpos( $url, $upload_url ) )
+                    throw new Aq_Exception('Image must be local: ' . $url);
+
+                // Define path of image.
+                $rel_path = str_replace( $upload_url, '', $url );
+                $img_path = $upload_dir . $rel_path;
+
+                // Check if img path exists, and is an image indeed.
+                if ( ! file_exists( $img_path ) or ! getimagesize( $img_path ) )
+                    throw new Aq_Exception('Image file does not exist (or is not an image): ' . $img_path);
+
+                // Get image info.
+                $info = pathinfo( $img_path );
+                $ext = $info['extension'];
+                list( $orig_w, $orig_h ) = getimagesize( $img_path );
+
+                // Get image size after cropping.
+                $dims = image_resize_dimensions( $orig_w, $orig_h, $width, $height, $crop );
+                $dst_w = $dims[4];
+                $dst_h = $dims[5];
+
+                // Return the original image only if it exactly fits the needed measures.
+                if ( ! $dims && ( ( ( null === $height && $orig_w == $width ) xor ( null === $width && $orig_h == $height ) ) xor ( $height == $orig_h && $width == $orig_w ) ) ) {
+                    $img_url = $url;
+                    $dst_w = $orig_w;
+                    $dst_h = $orig_h;
+                } else {
+                    // Use this to check if cropped image already exists, so we can return that instead.
+                    $suffix = "{$dst_w}x{$dst_h}";
+                    $dst_rel_path = str_replace( '.' . $ext, '', $rel_path );
+                    $destfilename = "{$upload_dir}{$dst_rel_path}-{$suffix}.{$ext}";
+
+                    if ( ! $dims || ( true == $crop && false == $upscale && ( $dst_w < $width || $dst_h < $height ) ) ) {
+                        // Can't resize, so return false saying that the action to do could not be processed as planned.
+                        throw new Aq_Exception('Unable to resize image because image_resize_dimensions() failed');
+                    }
+                    // Else check if cache exists.
+                    elseif ( file_exists( $destfilename ) && getimagesize( $destfilename ) ) {
+                        $img_url = "{$upload_url}{$dst_rel_path}-{$suffix}.{$ext}";
+                    }
+                    // Else, we resize the image and return the new resized image url.
+                    else {
+
+                        $editor = wp_get_image_editor( $img_path );
+
+                        if ( is_wp_error( $editor ) || is_wp_error( $editor->resize( $width, $height, $crop ) ) ) {
+                            throw new Aq_Exception('Unable to get WP_Image_Editor: ' . 
+                                                   $editor->get_error_message() . ' (is GD or ImageMagick installed?)');
+                        }
+
+                        $resized_file = $editor->save();
+
+                        if ( ! is_wp_error( $resized_file ) ) {
+                            $resized_rel_path = str_replace( $upload_dir, '', $resized_file['path'] );
+                            $img_url = $upload_url . $resized_rel_path;
+                        } else {
+                            throw new Aq_Exception('Unable to save resized image file: ' . $editor->get_error_message());
+                        }
+
+                    }
+                }
+
+                // Okay, leave the ship.
+                if ( true === $upscale ) remove_filter( 'image_resize_dimensions', array( $this, 'aq_upscale' ) );
+
+                // Return the output.
+                if ( $single ) {
+                    // str return.
+                    $image = $img_url;
+                } else {
+                    // array return.
+                    $image = array (
+                        0 => $img_url,
+                        1 => $dst_w,
+                        2 => $dst_h
+                    );
+                }
+
+                return $image;
             }
-            elseif(!strncmp($url,$http_prefix,strlen($http_prefix))){ //if url begins with http:// make $upload_url begin with http:// as well
-                $upload_url = str_replace($https_prefix,$http_prefix,$upload_url);      
-            }
-            
+            catch (Aq_Exception $ex) {
+                error_log('Aq_Resize.process() error: ' . $ex->getMessage());
 
-            // Check if $img_url is local.
-            if ( false === strpos( $url, $upload_url ) ) return false;
-
-            // Define path of image.
-            $rel_path = str_replace( $upload_url, '', $url );
-            $img_path = $upload_dir . $rel_path;
-
-            // Check if img path exists, and is an image indeed.
-            if ( ! file_exists( $img_path ) or ! getimagesize( $img_path ) ) return false;
-
-            // Get image info.
-            $info = pathinfo( $img_path );
-            $ext = $info['extension'];
-            list( $orig_w, $orig_h ) = getimagesize( $img_path );
-
-            // Get image size after cropping.
-            $dims = image_resize_dimensions( $orig_w, $orig_h, $width, $height, $crop );
-            $dst_w = $dims[4];
-            $dst_h = $dims[5];
-
-            // Return the original image only if it exactly fits the needed measures.
-            if ( ! $dims && ( ( ( null === $height && $orig_w == $width ) xor ( null === $width && $orig_h == $height ) ) xor ( $height == $orig_h && $width == $orig_w ) ) ) {
-                $img_url = $url;
-                $dst_w = $orig_w;
-                $dst_h = $orig_h;
-            } else {
-                // Use this to check if cropped image already exists, so we can return that instead.
-                $suffix = "{$dst_w}x{$dst_h}";
-                $dst_rel_path = str_replace( '.' . $ext, '', $rel_path );
-                $destfilename = "{$upload_dir}{$dst_rel_path}-{$suffix}.{$ext}";
-
-                if ( ! $dims || ( true == $crop && false == $upscale && ( $dst_w < $width || $dst_h < $height ) ) ) {
-                    // Can't resize, so return false saying that the action to do could not be processed as planned.
+                if ($this->throwOnError) {
+                    // Bubble up exception.
+                    throw $ex;
+                }
+                else {
+                    // Return false, so that this patch is backwards-compatible.
                     return false;
                 }
-                // Else check if cache exists.
-                elseif ( file_exists( $destfilename ) && getimagesize( $destfilename ) ) {
-                    $img_url = "{$upload_url}{$dst_rel_path}-{$suffix}.{$ext}";
-                }
-                // Else, we resize the image and return the new resized image url.
-                else {
-
-                    $editor = wp_get_image_editor( $img_path );
-
-                    if ( is_wp_error( $editor ) || is_wp_error( $editor->resize( $width, $height, $crop ) ) )
-                        return false;
-
-                    $resized_file = $editor->save();
-
-                    if ( ! is_wp_error( $resized_file ) ) {
-                        $resized_rel_path = str_replace( $upload_dir, '', $resized_file['path'] );
-                        $img_url = $upload_url . $resized_rel_path;
-                    } else {
-                        return false;
-                    }
-
-                }
             }
-
-            // Okay, leave the ship.
-            if ( true === $upscale ) remove_filter( 'image_resize_dimensions', array( $this, 'aq_upscale' ) );
-
-            // Return the output.
-            if ( $single ) {
-                // str return.
-                $image = $img_url;
-            } else {
-                // array return.
-                $image = array (
-                    0 => $img_url,
-                    1 => $dst_w,
-                    2 => $dst_h
-                );
-            }
-
-            return $image;
         }
 
         /**


### PR DESCRIPTION
This plugin was silently failing when my server didn't have GD or ImageMagick installed. The `aq_resize()` function was simply returning false. I've added more detailed error logging (and the option to raise an exception if `Aq_Resize::$throwOnError` is set).

Summary of changes:

- All errors are logged with error_log() to make troubleshooting easier
- Errors will raise an Aq_Exception if $throwOnError is true
- Old behavior of returning false is still preserved