### PR TITLE
Bugfix: Prevent replacing string occurences of extension in filename 

### DIFF
--- a/aq_resizer.php
+++ b/aq_resizer.php
@@ -125,7 +125,9 @@ if(!class_exists('Aq_Resize')) {
                 } else {
                     // Use this to check if cropped image already exists, so we can return that instead.
                     $suffix = "{$dst_w}x{$dst_h}";
-                    $dst_rel_path = str_replace( '.' . $ext, '', $rel_path );
+                    // Only replace actual extension to prevent replacing extension string occurrence in filename
+                    $ext_pos = strrpos( $rel_path, $ext );
+                    $dst_rel_path = substr_replace( $rel_path, '', $ext_pos - 1, strlen( $ext ) + 1 );
                     $destfilename = "{$upload_dir}{$dst_rel_path}-{$suffix}.{$ext}";
 
                     if ( ! $dims || ( true == $crop && false == $upscale && ( $dst_w < $width || $dst_h < $height ) ) ) {


### PR DESCRIPTION
Hi!

Any filenames with the extension in it are being stripped out from this line:

https://github.com/syamilmj/Aqua-Resizer/blob/57fe7e7877381483c0d7bf90cd34951066d8b5f3/aq_resizer.php#L128

And thus, fails this check here: 

https://github.com/syamilmj/Aqua-Resizer/blob/57fe7e7877381483c0d7bf90cd34951066d8b5f3/aq_resizer.php#L136

E.g. `/2019/01/filename.jpg-hello.jpg-test-name.jpg`, where all occurrences of `jpg` become stripped out when only the actual extension at the end of it should be.  This patch looks for the last occurrence of the extension at the end and strips it out by position instead.