### PR TITLE
Fix use with WPML

### DIFF
--- a/aq_resizer.php
+++ b/aq_resizer.php
@@ -233,13 +233,6 @@ if(!function_exists('aq_resize')) {
      * need to change any code in your own WP themes. Usage is still the same :)
      */
     function aq_resize( $url, $width = null, $height = null, $crop = null, $single = true, $upscale = false ) {
-        /* WPML Fix */
-        if ( defined( 'ICL_SITEPRESS_VERSION' ) ){
-            global $sitepress;
-            $url = $sitepress->convert_url( $url, $sitepress->get_default_language() );
-        }
-        /* WPML Fix */
-
         $aq_resize = Aq_Resize::getInstance();
         return $aq_resize->process( $url, $width, $height, $crop, $single, $upscale );
     }


### PR DESCRIPTION
The code snippet set for use with WPML is no longer necessary, and now have the opposite effect.